### PR TITLE
Close #13 app-ci 실행 조건을 app폴더로 제한

### DIFF
--- a/.github/workflows/app-ci.yml
+++ b/.github/workflows/app-ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
       - master
+    paths:
+      - "app/**"
+      - "!app/**/ios/**"
 
 defaults:
   run:


### PR DESCRIPTION
+ on : pull_request 조건에 path 조건을 추가
+ 우선은 안드로이드만 진행하므로 ios 빌드 관련 폴더도 ignore 하도록 설정